### PR TITLE
Feature/allow-additional-attributes-in-AbstractAttributeValueJSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@nmshd/content",
-    "version": "2.0.0-alpha.40",
+    "version": "2.0.0-alpha.41",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@nmshd/content",
-            "version": "2.0.0-alpha.40",
+            "version": "2.0.0-alpha.41",
             "license": "MIT",
             "dependencies": {
                 "@js-soft/logging-abstractions": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nmshd/content",
-    "version": "2.0.0-alpha.40",
+    "version": "2.0.0-alpha.41",
     "description": "The content library defines data structures that can be transmitted using the transport library.",
     "homepage": "https://enmeshed.eu",
     "repository": "github:nmshd/cns-content",

--- a/src/attributes/AbstractAttributeValue.ts
+++ b/src/attributes/AbstractAttributeValue.ts
@@ -6,7 +6,7 @@ import { AbstractFloat } from "./types/AbstractFloat"
 import { AbstractInteger } from "./types/AbstractInteger"
 import { AbstractString } from "./types/AbstractString"
 
-export interface AbstractAttributeValueJSON extends ContentJSON {}
+export interface AbstractAttributeValueJSON extends ContentJSON, Record<string, unknown> {}
 
 export interface IAbstractAttributeValue extends ISerializable {}
 


### PR DESCRIPTION
Das ist nur eine vorübergehende Lösung. Später werden wir für IdentityAttribute und RelationshipAttribute sowieso jeweils eigene Types haben (IdentityAttributeValues und RelationshipAttributeValues). Damit fällt dieser Workaround dann weg. Vorerst brauchen wir ihn aber, weil, es sonst bei der Validierung in der Runtime Probleme gibt.